### PR TITLE
Simple fix to discretization warning

### DIFF
--- a/weka/classifiers.py
+++ b/weka/classifiers.py
@@ -383,7 +383,7 @@ class Classifier(object):
                 print('stderr:')
                 print(stderr_str)
             # exclude "Warning" lines not to raise an error for a simple warning
-            stderr_str = '\n'.join(l for l in stderr_str.split('\n') if not "Warning" in l)
+            stderr_str = '\n'.join(l for l in stderr_str.decode('utf8').split('\n') if not "Warning" in l)
             if stderr_str:
                 raise TrainingError(stderr_str)
             
@@ -532,7 +532,7 @@ class Classifier(object):
                     # Check for distribution output.
                     matches = re.findall(
                         r"^\s*[0-9\.]+\s+[a-zA-Z0-9\.\?\:]+\s+(?P<cls_value>[a-zA-Z0-9_\.\?\:]+)\s+\+?\s+(?P<prob>[a-zA-Z0-9\.\?\,\*]+)",
-                        stdout_str,
+                        stdout_str.decode('utf-8'),
                         re.MULTILINE)
                     assert matches, ("No results found matching distribution pattern in stdout: %s") % stdout_str
                     for match in matches:

--- a/weka/classifiers.py
+++ b/weka/classifiers.py
@@ -382,6 +382,8 @@ class Classifier(object):
                 print(stdout_str)
                 print('stderr:')
                 print(stderr_str)
+            # exclude "Warning" lines not to raise an error for a simple warning
+            stderr_str = '\n'.join(l for l in stderr_str.split('\n') if not "Warning" in l)
             if stderr_str:
                 raise TrainingError(stderr_str)
             


### PR DESCRIPTION
**Problem**: When using classifier `weka.classifiers.bayes.BayesNet`, execution was stopped while raising a message "*Warning: discretizing data set*", simply telling that Weka has discretized the input data. However, `classifiers.py` raises `TrainingError` if `stderr_str` is not `None`, even if it is only a warning.

**Solution**: Simply filter *Warning* lines from `stderr_str` so that it will not raise `TrainingError` for a simple warning.